### PR TITLE
fix: Update checklist when signing/unsigning only

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/procosys-webapp-components",
-  "version": "1.12.2",
+  "version": "1.12.4",
   "description": "Standalone module for filling out, editing, signing and unsigning MCCR checklists.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/modules/Checklist/Checklist.tsx
+++ b/src/modules/Checklist/Checklist.tsx
@@ -101,10 +101,6 @@ const Checklist = (props: ChecklistProps): JSX.Element => {
     }, [checkItems, customCheckItems]);
 
     useEffect(() => {
-        props.refreshChecklistStatus((prev: boolean) => !prev);
-    }, [isSigned]);
-
-    useEffect(() => {
         (async (): Promise<void> => {
             try {
                 const checklistResponse = await api.getChecklist(source.token);
@@ -224,6 +220,7 @@ const Checklist = (props: ChecklistProps): JSX.Element => {
                         api={api}
                         setMultiSignOrVerifyIsOpen={setMultiSignOrVerifyIsOpen}
                         multiSignOrVerifyIsOpen={multiSignOrVerifyIsOpen}
+                        refreshChecklistStatus={props.refreshChecklistStatus}
                     />
                 )}
             </>

--- a/src/modules/Checklist/ChecklistMultiSignOrVerify.tsx
+++ b/src/modules/Checklist/ChecklistMultiSignOrVerify.tsx
@@ -45,6 +45,7 @@ type ChecklistMultiSignOrVerifyProps = {
     tagNo: string;
     api: ProcosysApiService;
     setSnackbarText: (message: string) => void;
+    refreshChecklistStatus: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 const ChecklistMultiSignOrVerify = ({
@@ -54,6 +55,7 @@ const ChecklistMultiSignOrVerify = ({
     tagNo,
     api,
     setSnackbarText,
+    refreshChecklistStatus,
 }: ChecklistMultiSignOrVerifyProps): JSX.Element => {
     const [itemsToSignOrVerify, setItemsToSignOrVerify] = useState(
         eligibleItems.map((item) => item.id)
@@ -68,6 +70,11 @@ const ChecklistMultiSignOrVerify = ({
         setAllAreChecked(itemsToSignOrVerify.length === eligibleItems.length);
     }, [itemsToSignOrVerify]);
 
+    const closeMultiSignOrVerifyAndRefresh = (): void => {
+        setMultiSignOrVerifyIsOpen(false);
+        refreshChecklistStatus((prev: boolean) => !prev);
+    };
+
     const handleMultiSignOrVerify = async (): Promise<void> => {
         setPostSignOrVerifyStatus(AsyncStatus.LOADING);
         try {
@@ -79,7 +86,7 @@ const ChecklistMultiSignOrVerify = ({
                 setSnackbarText('Additional MCCRs signed.');
             }
             setPostSignOrVerifyStatus(AsyncStatus.SUCCESS);
-            setMultiSignOrVerifyIsOpen(false);
+            closeMultiSignOrVerifyAndRefresh();
         } catch (error) {
             if (!(error instanceof Error)) return;
             setPostSignOrVerifyStatus(AsyncStatus.ERROR);
@@ -122,10 +129,7 @@ const ChecklistMultiSignOrVerify = ({
     };
 
     return (
-        <Scrim
-            isDismissable
-            onClose={(): void => setMultiSignOrVerifyIsOpen(false)}
-        >
+        <Scrim isDismissable onClose={closeMultiSignOrVerifyAndRefresh}>
             <MultiSignVerifyContainer>
                 <p>
                     MCCR {isMultiVerify ? 'verified' : 'signed'} for tag: <br />
@@ -165,7 +169,7 @@ const ChecklistMultiSignOrVerify = ({
                 <ButtonWrapper>
                     <Button
                         variant={'outlined'}
-                        onClick={(): void => setMultiSignOrVerifyIsOpen(false)}
+                        onClick={closeMultiSignOrVerifyAndRefresh}
                     >
                         Close
                     </Button>

--- a/src/modules/Checklist/ChecklistSignature.tsx
+++ b/src/modules/Checklist/ChecklistSignature.tsx
@@ -82,6 +82,7 @@ type ChecklistSignatureProps = {
     api: ProcosysApiService;
     setMultiSignOrVerifyIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
     multiSignOrVerifyIsOpen: boolean;
+    refreshChecklistStatus: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 const ChecklistSignature = ({
@@ -94,6 +95,7 @@ const ChecklistSignature = ({
     api,
     setMultiSignOrVerifyIsOpen,
     multiSignOrVerifyIsOpen,
+    refreshChecklistStatus,
 }: ChecklistSignatureProps): JSX.Element => {
     const [comment, setComment] = useState(details.comment);
     const [putCommentStatus, setPutCommentStatus] = useState(
@@ -131,6 +133,7 @@ const ChecklistSignature = ({
             reloadChecklist((reloadStatus) => !reloadStatus);
             setSignStatus(AsyncStatus.SUCCESS);
             setIsSigned(false);
+            refreshChecklistStatus((prev: boolean) => !prev);
         } catch (error) {
             if (!(error instanceof Error)) return;
             setSignStatus(AsyncStatus.ERROR);
@@ -155,6 +158,7 @@ const ChecklistSignature = ({
                 setSnackbarText(
                     isSigned ? 'Unsign complete.' : 'Signing complete.'
                 );
+                refreshChecklistStatus((prev: boolean) => !prev);
             } else {
                 setMultiSignOrVerifyIsOpen(true);
             }
@@ -349,6 +353,7 @@ const ChecklistSignature = ({
                     api={api}
                     setMultiSignOrVerifyIsOpen={setMultiSignOrVerifyIsOpen}
                     setSnackbarText={setSnackbarText}
+                    refreshChecklistStatus={refreshChecklistStatus}
                 />
             ) : null}
         </ChecklistSignatureWrapper>

--- a/yarn.lock
+++ b/yarn.lock
@@ -149,10 +149,10 @@
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
   integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
 
-"@equinor/eds-core-react@^0.14.0":
-  version "0.14.1"
-  resolved "https://registry.yarnpkg.com/@equinor/eds-core-react/-/eds-core-react-0.14.1.tgz#737b30bf6cbbacbf3518807e20cc0d1259e131fc"
-  integrity sha512-EEpxT16WzqiV+igtRiErDnWAqwbwdHogRmhmXNRQvYF8k49nslk07hBTdTlha+Xq53+CFcWV9IyAsZUm8NhRJA==
+"@equinor/eds-core-react@^0.14.1":
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/@equinor/eds-core-react/-/eds-core-react-0.14.2.tgz#b2469550cc98b1082ba034b1c3724229c46622ed"
+  integrity sha512-upp46xX601fhhqnWkq4TB4IKbK0QRmEjRUqPnDkHISPgId+e0TXixCB4OwdO3IxJHBdTwD1MW8Z66H5EpqyxZw==
   dependencies:
     "@equinor/eds-icons" "0.7.0"
     "@equinor/eds-tokens" "0.7.0"


### PR DESCRIPTION
The `refreshChecklistStatus` function was being called when rendering the component. It should only be called when a checklist is signed or unsigned.

In the case of multisigning, the refresh function is postponed until the modal is closed by the user to prevent the UI from updating with the new checklist status and closing the modal automatically.