### PR TITLE
Bug/ 92033 unable to open some checklists from echo and ProCoSys mc app

### DIFF
--- a/src/modules/Checklist/CheckItems/CheckHeader.tsx
+++ b/src/modules/Checklist/CheckItems/CheckHeader.tsx
@@ -24,7 +24,7 @@ const GreyText = styled.p`
 `;
 
 type CheckHeaderProps = {
-    text: string;
+    text: string | null;
     addLabels?: boolean;
 };
 

--- a/src/services/apiTypeGuards.ts
+++ b/src/services/apiTypeGuards.ts
@@ -52,7 +52,9 @@ const isChecklistDetails = (data: unknown): data is ChecklistDetails => {
 };
 
 const isCheckItem = (data: unknown): data is CheckItem => {
-    return data != null && typeof (data as CheckItem).text === 'string';
+    return (
+        data != null && typeof (data as CheckItem).hasMetaTable === 'boolean'
+    );
 };
 
 const isArrayOfCheckItems = (data: unknown): data is CheckItem[] => {
@@ -60,7 +62,7 @@ const isArrayOfCheckItems = (data: unknown): data is CheckItem[] => {
 };
 
 const isCustomCheckItem = (data: unknown): data is CustomCheckItem => {
-    return data != null && typeof (data as CustomCheckItem).text === 'string';
+    return data != null && typeof (data as CustomCheckItem).isOk === 'boolean';
 };
 
 const isArrayOfCustomCheckItems = (

--- a/src/typings/apiTypes.ts
+++ b/src/typings/apiTypes.ts
@@ -108,13 +108,13 @@ export interface MetaTable {
 export interface CheckItem {
     id: number;
     sequenceNumber: string;
-    text: string;
-    detailText: string;
+    text: string | null;
+    detailText: string | null;
     isHeading: boolean;
     hasImage: boolean;
     imageFileId: number;
     hasMetaTable: boolean;
-    metaTable: MetaTable;
+    metaTable: MetaTable | null;
     isOk: boolean;
     isNotApplicable: boolean;
 }


### PR DESCRIPTION
AB#92033

The type guarding used for CheckItems caused checklists with empty rows to fail in the MC app. 