### PR TITLE
Feature/106508 make offline more visible

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/procosys-webapp-components",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Library for sharing components and modules between Procosys MC webapp, Comm webapp and Echo.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -1,18 +1,21 @@
 import React from 'react';
 import styled from 'styled-components';
 import { BREAKPOINT, COLORS } from '../style/GlobalStyles';
+import { Button, Icon, Typography } from '@equinor/eds-core-react';
+import EdsIcon from './icons/EdsIcon';
 
 const NavbarWrapper = styled.nav<{ noBorder: boolean; isOffline: boolean }>`
     height: 54px;
     width: 100%;
     max-width: 768px;
-    background-color: ${COLORS.white};
+    background-color: ${({ isOffline }): string =>
+        isOffline ? `${COLORS.midnight}` : `${COLORS.white}`};
     border-bottom: ${({ noBorder }): string =>
         noBorder ? 'none' : `1px solid ${COLORS.fadedBlue}`};
-    border-top: ${({ isOffline }): string =>
-        isOffline ? `3px solid ${COLORS.danger}` : `none`};
     display: flex;
     flex-grow: 100;
+    color: ${({ isOffline }): string =>
+        isOffline ? `${COLORS.moss}` : `${COLORS.mossGreen}`};
     justify-content: space-between;
     align-items: center;
     box-sizing: border-box;
@@ -42,6 +45,10 @@ const NavbarWrapper = styled.nav<{ noBorder: boolean; isOffline: boolean }>`
     }
 `;
 
+export const NavButton = styled(Button)`
+    color: inherit;
+`;
+
 type NavbarProps = {
     leftContent?: JSX.Element;
     midContent?: string;
@@ -57,11 +64,23 @@ const Navbar = ({
     noBorder = false,
     isOffline = false,
 }: NavbarProps): JSX.Element => {
+    console.log(COLORS.moss);
     return (
         <>
             <NavbarWrapper noBorder={noBorder} isOffline={isOffline}>
                 {leftContent}
-                <h4>{midContent}</h4>
+                <Typography variant="h4" color={isOffline ? COLORS.white : ''}>
+                    {isOffline && (
+                        <EdsIcon
+                            name={'wifi_off'}
+                            title={'wifi_off'}
+                            size={24}
+                            color={COLORS.white}
+                        />
+                    )}{' '}
+                    {midContent}
+                </Typography>
+
                 {rightContent}
             </NavbarWrapper>
         </>

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -43,6 +43,15 @@ const NavbarWrapper = styled.nav<{ noBorder: boolean; isOffline: boolean }>`
     ${BREAKPOINT.standard} {
         padding: 4px 4%;
     }
+    & > span {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        text-align: center;
+    }
+    & > div {
+        width: 48px;
+    }
 `;
 
 export const NavButton = styled(Button)`
@@ -64,12 +73,11 @@ const Navbar = ({
     noBorder = false,
     isOffline = false,
 }: NavbarProps): JSX.Element => {
-    console.log(COLORS.moss);
     return (
         <>
             <NavbarWrapper noBorder={noBorder} isOffline={isOffline}>
                 {leftContent}
-                <Typography variant="h4" color={isOffline ? COLORS.white : ''}>
+                <span>
                     {isOffline && (
                         <EdsIcon
                             name={'wifi_off'}
@@ -78,10 +86,15 @@ const Navbar = ({
                             color={COLORS.white}
                         />
                     )}{' '}
-                    {midContent}
-                </Typography>
+                    <Typography
+                        variant="h4"
+                        color={isOffline ? COLORS.white : ''}
+                    >
+                        {midContent}
+                    </Typography>
+                </span>
 
-                {rightContent}
+                {rightContent ? rightContent : <div> </div>}
             </NavbarWrapper>
         </>
     );

--- a/src/components/buttons/BackButton.tsx
+++ b/src/components/buttons/BackButton.tsx
@@ -3,6 +3,9 @@ import React from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 import removeSubdirectories from '../../utils/removeSubdirectories';
 import EdsIcon from '../icons/EdsIcon';
+import styled from 'styled-components';
+import { COLORS } from '../../style/GlobalStyles';
+import { NavButton } from '../NavBar';
 
 type BackButtonProps = {
     to?: string;
@@ -12,7 +15,7 @@ const BackButton = ({ to }: BackButtonProps): JSX.Element => {
     const history = useHistory();
     const { pathname } = useLocation();
     return (
-        <Button
+        <NavButton
             variant="ghost"
             onClick={(): void => {
                 if (to) {
@@ -24,7 +27,7 @@ const BackButton = ({ to }: BackButtonProps): JSX.Element => {
         >
             <EdsIcon name={'arrow_back'} title="Back" />
             Back
-        </Button>
+        </NavButton>
     );
 };
 

--- a/src/components/buttons/ProcosysButton.tsx
+++ b/src/components/buttons/ProcosysButton.tsx
@@ -2,6 +2,7 @@ import { Button } from '@equinor/eds-core-react';
 import React from 'react';
 import styled from 'styled-components';
 import ProcosysLogo from '../../assets/img/ProCoSys_icon.svg';
+import { NavButton } from '../NavBar';
 
 const ProcosysIcon = styled.img`
     width: 18px;
@@ -10,10 +11,10 @@ const ProcosysIcon = styled.img`
 
 const ProcosysButton = (): JSX.Element => {
     return (
-        <Button variant="ghost">
+        <NavButton variant="ghost">
             <ProcosysIcon src={ProcosysLogo} />
             ProCoSys
-        </Button>
+        </NavButton>
     );
 };
 

--- a/src/components/icons/EdsIcon.tsx
+++ b/src/components/icons/EdsIcon.tsx
@@ -44,6 +44,7 @@ import {
     launch,
     camera_add_photo,
     download,
+    wifi_off,
 } from '@equinor/eds-icons';
 import { Icon } from '@equinor/eds-core-react';
 import React from 'react';
@@ -94,6 +95,7 @@ Icon.add({
     add,
     launch,
     download,
+    wifi_off,
 });
 
 type IconProps = {

--- a/src/style/GlobalStyles.tsx
+++ b/src/style/GlobalStyles.tsx
@@ -18,6 +18,7 @@ export const COLORS = {
     greyBackground: tokens.colors.ui.background__light.hex,
     disabledText: tokens.colors.interactive.disabled__text.hex,
     black: '#000',
+    moss: tokens.colors.interactive.link_in_snackbars.hex,
 };
 
 const GlobalStyles = createGlobalStyle`


### PR DESCRIPTION
[AB#106508](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/106508)

Render color and backgroundcolor based on offlinemode.
Add icon based on offline mode, and add the right styling to keep content in right places, with text + icon in the middle.
Add empty div to the right if no element is added. This makes sure the middlecontent stays in the middle.