### PR TITLE
fix: native checkbox fallback on iOS/Safari for EDS Checkbox

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/procosys-webapp-components",
-  "version": "6.1.4",
+  "version": "6.1.5",
   "description": "Library for sharing components and modules between Procosys MC webapp, Comm webapp and Echo.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/style/GlobalStyles.tsx
+++ b/src/style/GlobalStyles.tsx
@@ -52,6 +52,28 @@ const GlobalStyles = createGlobalStyle`
     label {
         ${tokens.typography.input.label as CSSObject}
     }
+    /* iPad/iOS Safari fix: EDS Checkbox renders ticked/unticked state by
+       toggling display:none/inline on SVG <path> elements via a sibling
+       :checked selector. WebKit on iOS does not repaint SVG <path> elements
+       when display is toggled this way, so ticked boxes keep showing the empty
+       outline. On iOS only, hide the broken SVG overlay and fall back to the
+       native browser checkbox, which renders the checked state correctly.
+       '@supports (-webkit-touch-callout: none)' matches iOS/iPadOS Safari
+       exclusively, so desktop EDS styling is unaffected. */
+    @supports (-webkit-touch-callout: none) {
+        input[type='checkbox'] ~ svg {
+            display: none;
+        }
+        input[type='checkbox'] {
+            appearance: auto;
+            -webkit-appearance: checkbox;
+            transform: none;
+            width: 24px;
+            height: 24px;
+            margin: 0;
+            accent-color: ${COLORS.mossGreen};
+        }
+    }
     caption { 
         ${tokens.typography.paragraph.caption as CSSObject}
     }


### PR DESCRIPTION
## Summary

Fixes ticked checkboxes rendering as empty outlines on **iOS/Safari** for the EDS `Checkbox`.

## Problem

EDS `Checkbox` renders its checked state by toggling `display: none/inline` on SVG `<path>` elements via a sibling `:checked` selector. WebKit on iOS does **not** repaint an SVG `<path>` when `display` is toggled this way, so ticked boxes keep showing the empty outline.

## Fix

On iOS only — scoped with `@supports (-webkit-touch-callout: none)` — hide the EDS SVG overlay and fall back to the **native** checkbox, which renders the checked state correctly. Desktop EDS styling is unaffected.

## Changes
- `src/style/GlobalStyles.tsx` — iOS-scoped checkbox fallback styles

## Validation
- Desktop EDS checkbox appearance unchanged
- iOS Safari now shows the checked state