### PR TITLE
Publish to npmjs under @equinor scope via Trusted Publisher OIDC

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  packages: write
 
 jobs:
   publish:
@@ -18,8 +19,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          registry-url: https://registry.npmjs.org
-          scope: '@equinor'
+          registry-url: https://npm.pkg.github.com
+          scope: '@procosys'
           cache: yarn
 
       - name: Install dependencies
@@ -39,9 +40,11 @@ jobs:
           else
             echo "should_publish=true" >> "$GITHUB_OUTPUT"
           fi
-
-      - name: Publish to npm
-        if: steps.check.outputs.should_publish == 'true'
-        run: npm publish --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.PROCOSYS_NPM_TOKEN }}
+
+      - name: Publish to GitHub Packages
+        if: steps.check.outputs.should_publish == 'true'
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.PROCOSYS_NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,6 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   publish:
@@ -19,7 +18,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          registry-url: https://npm.pkg.github.com
+          registry-url: https://registry.npmjs.org
           scope: '@equinor'
           cache: yarn
 
@@ -40,11 +39,9 @@ jobs:
           else
             echo "should_publish=true" >> "$GITHUB_OUTPUT"
           fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Publish to GitHub Packages
+      - name: Publish to npm
         if: steps.check.outputs.should_publish == 'true'
-        run: npm publish
+        run: npm publish --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
 
 permissions:
   contents: read
-  packages: write
+  id-token: write
 
 jobs:
   publish:
@@ -19,9 +19,12 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          registry-url: https://npm.pkg.github.com
-          scope: '@procosys'
+          registry-url: https://registry.npmjs.org
+          scope: "@equinor"
           cache: yarn
+
+      - name: Update npm for OIDC trusted publishing
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
@@ -40,11 +43,7 @@ jobs:
           else
             echo "should_publish=true" >> "$GITHUB_OUTPUT"
           fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.PROCOSYS_NPM_TOKEN }}
 
-      - name: Publish to GitHub Packages
+      - name: Publish to npmjs
         if: steps.check.outputs.should_publish == 'true'
         run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.PROCOSYS_NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -26,37 +26,27 @@ For info on how to contribute and publish changes to the package, please check o
 
 ## Installing the package
 
-This package is published to **GitHub Packages** (not npmjs.com). To install it, configure npm/yarn to resolve the `@equinor` scope from the GitHub Packages registry.
+This package is published to **npmjs.com** under the public `@equinor` scope, so no special registry configuration is required. Install it like any other dependency:
 
-1. Create or update an `.npmrc` file in the root of your project:
+```
+yarn add @equinor/procosys-webapp-components
+```
 
-   ```
-   @equinor:registry=https://npm.pkg.github.com
-   //npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
-   ```
+or
 
-2. Provide a GitHub Personal Access Token (classic) with the `read:packages` scope via the `GITHUB_TOKEN` environment variable (or paste the token directly in `.npmrc`, but never commit it):
-
-   ```
-   export GITHUB_TOKEN=your_token_here
-   ```
-
-3. Install the package:
-
-   ```
-   yarn add @equinor/procosys-webapp-components
-   ```
-
-   or
-
-   ```
-   npm install @equinor/procosys-webapp-components
-   ```
-
-In CI, you can use the automatically provided `GITHUB_TOKEN` secret instead of a personal access token.
+```
+npm install @equinor/procosys-webapp-components
+```
 
 ## Publishing
 
-Publishing is automated via the `Publish package` GitHub Actions workflow (`.github/workflows/publish.yml`). On every push to `main`, the workflow builds the package and publishes it to GitHub Packages **only if** the version in `package.json` has not already been published.
+Publishing is automated via the `Publish package` GitHub Actions workflow (`.github/workflows/publish.yml`). On every push to `main`, the workflow builds the package and publishes it to npmjs.com **only if** the version in `package.json` has not already been published. This means routine commits to `main` won't fail when the version is unchanged.
 
-To release a new version, bump the `version` field in `package.json` and merge to `main`.
+To release a new version:
+
+1. Bump the `version` field in `package.json`.
+2. Merge to `main`. The workflow publishes the new version automatically.
+
+### Required secret
+
+The workflow authenticates with npm using an `NPM_TOKEN` repository (or organization) secret. Create an npm **Automation** access token for an account with publish rights to the `@equinor` scope, then add it under **Settings → Secrets and variables → Actions** as `NPM_TOKEN`.

--- a/README.md
+++ b/README.md
@@ -17,30 +17,49 @@ How to use this library:
 
 To link to this library
 * Run "yarn start"
-* Run "yarn link @equinor/procosys-webapp-components" in the app you want to test the code in.
+* Run "yarn link @procosys/procosys-webapp-components" in the app you want to test the code in.
 
 To unlink
-* Run "yarn unlink @equinor/procosys-webapp-components" in the app you tested the code in.
+* Run "yarn unlink @procosys/procosys-webapp-components" in the app you tested the code in.
 
 For info on how to contribute and publish changes to the package, please check out the guide in the Procosys Wiki Frontend section.
 
 ## Installing the package
 
-This package is published to **npmjs.com** under the public `@equinor` scope, so no special registry configuration is required. Install it like any other dependency:
+This package is published to **GitHub Packages** under the `@procosys` scope (owned by the [ProCoSys](https://github.com/ProCoSys) organization). The `@procosys` scope is independent of the `@equinor` scope, so the EDS packages (`@equinor/eds-*`) and other `@equinor` dependencies continue to be resolved from npmjs.com as normal.
 
-```
-yarn add @equinor/procosys-webapp-components
-```
+1. In the consuming project, create or update an `.npmrc` file in the repository root to route **only** the `@procosys` scope to GitHub Packages:
 
-or
+   ```
+   @procosys:registry=https://npm.pkg.github.com
+   //npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}
+   ```
 
-```
-npm install @equinor/procosys-webapp-components
-```
+   Leave the `@equinor` scope untouched so it keeps resolving from the default npmjs.com registry.
+
+2. Provide a GitHub Personal Access Token (classic) with the `read:packages` scope (with access to the ProCoSys organization) via the `NODE_AUTH_TOKEN` environment variable:
+
+   ```
+   export NODE_AUTH_TOKEN=your_token_here
+   ```
+
+   In CI (GitHub Actions), the automatically provided `GITHUB_TOKEN` works if the workflow runs in the ProCoSys organization; otherwise use a PAT secret.
+
+3. Install the package:
+
+   ```
+   yarn add @procosys/procosys-webapp-components
+   ```
+
+   or
+
+   ```
+   npm install @procosys/procosys-webapp-components
+   ```
 
 ## Publishing
 
-Publishing is automated via the `Publish package` GitHub Actions workflow (`.github/workflows/publish.yml`). On every push to `main`, the workflow builds the package and publishes it to npmjs.com **only if** the version in `package.json` has not already been published. This means routine commits to `main` won't fail when the version is unchanged.
+Publishing is automated via the `📦 Publish package` GitHub Actions workflow (`.github/workflows/publish.yml`). On every push to `main`, the workflow builds the package and publishes it to GitHub Packages **only if** the version in `package.json` has not already been published. This means routine commits to `main` won't fail when the version is unchanged.
 
 To release a new version:
 
@@ -49,4 +68,6 @@ To release a new version:
 
 ### Required secret
 
-The workflow authenticates with npm using an `NPM_TOKEN` repository (or organization) secret. Create an npm **Automation** access token for an account with publish rights to the `@equinor` scope, then add it under **Settings → Secrets and variables → Actions** as `NPM_TOKEN`.
+Because this repository lives in the `equinor` organization but the package is published to the `@procosys` (ProCoSys org) GitHub Packages registry, the workflow authenticates using a **`PROCOSYS_NPM_TOKEN`** secret. Create a GitHub Personal Access Token (classic) with the `write:packages` scope and access to the ProCoSys organization, then add it under **Settings → Secrets and variables → Actions** as `PROCOSYS_NPM_TOKEN`.
+
+> If this repository is moved to the ProCoSys organization, the workflow can be simplified to use the automatic `GITHUB_TOKEN` instead of a PAT.

--- a/README.md
+++ b/README.md
@@ -17,57 +17,40 @@ How to use this library:
 
 To link to this library
 * Run "yarn start"
-* Run "yarn link @procosys/procosys-webapp-components" in the app you want to test the code in.
+* Run "yarn link @equinor/procosys-webapp-components" in the app you want to test the code in.
 
 To unlink
-* Run "yarn unlink @procosys/procosys-webapp-components" in the app you tested the code in.
+* Run "yarn unlink @equinor/procosys-webapp-components" in the app you tested the code in.
 
 For info on how to contribute and publish changes to the package, please check out the guide in the Procosys Wiki Frontend section.
 
 ## Installing the package
 
-This package is published to **GitHub Packages** under the `@procosys` scope (owned by the [ProCoSys](https://github.com/ProCoSys) organization). The `@procosys` scope is independent of the `@equinor` scope, so the EDS packages (`@equinor/eds-*`) and other `@equinor` dependencies continue to be resolved from npmjs.com as normal.
+This package is published to **npmjs.com** under the `@equinor` scope, alongside the EDS packages (`@equinor/eds-*`) and other `@equinor` dependencies.
 
-1. In the consuming project, create or update an `.npmrc` file in the repository root to route **only** the `@procosys` scope to GitHub Packages:
-
-   ```
-   @procosys:registry=https://npm.pkg.github.com
-   //npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}
-   ```
-
-   Leave the `@equinor` scope untouched so it keeps resolving from the default npmjs.com registry.
-
-2. Provide a GitHub Personal Access Token (classic) with the `read:packages` scope (with access to the ProCoSys organization) via the `NODE_AUTH_TOKEN` environment variable:
+1. Install the package:
 
    ```
-   export NODE_AUTH_TOKEN=your_token_here
-   ```
-
-   In CI (GitHub Actions), the automatically provided `GITHUB_TOKEN` works if the workflow runs in the ProCoSys organization; otherwise use a PAT secret.
-
-3. Install the package:
-
-   ```
-   yarn add @procosys/procosys-webapp-components
+   yarn add @equinor/procosys-webapp-components
    ```
 
    or
 
    ```
-   npm install @procosys/procosys-webapp-components
+   npm install @equinor/procosys-webapp-components
    ```
+
+No `.npmrc` or auth token is required for installing, since the package is public on npmjs.com.
 
 ## Publishing
 
-Publishing is automated via the `📦 Publish package` GitHub Actions workflow (`.github/workflows/publish.yml`). On every push to `main`, the workflow builds the package and publishes it to GitHub Packages **only if** the version in `package.json` has not already been published. This means routine commits to `main` won't fail when the version is unchanged.
+Publishing is automated via the `📦 Publish package` GitHub Actions workflow (`.github/workflows/publish.yml`). On every push to `main`, the workflow builds the package and publishes it to npmjs.com **only if** the version in `package.json` has not already been published. This means routine commits to `main` won't fail when the version is unchanged.
 
 To release a new version:
 
 1. Bump the `version` field in `package.json`.
 2. Merge to `main`. The workflow publishes the new version automatically.
 
-### Required secret
+### Authentication (Trusted Publisher / OIDC)
 
-Because this repository lives in the `equinor` organization but the package is published to the `@procosys` (ProCoSys org) GitHub Packages registry, the workflow authenticates using a **`PROCOSYS_NPM_TOKEN`** secret. Create a GitHub Personal Access Token (classic) with the `write:packages` scope and access to the ProCoSys organization, then add it under **Settings → Secrets and variables → Actions** as `PROCOSYS_NPM_TOKEN`.
-
-> If this repository is moved to the ProCoSys organization, the workflow can be simplified to use the automatic `GITHUB_TOKEN` instead of a PAT.
+Publishing uses npm's **Trusted Publisher** (OIDC) feature, so no npm token is required. The workflow authenticates tokenlessly via GitHub Actions OIDC (`id-token: write` permission). The package on npmjs.com must have this repository and the `publish.yml` workflow configured as a Trusted Publisher.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@procosys/procosys-webapp-components",
-  "version": "1.0.0",
+  "name": "@equinor/procosys-webapp-components",
+  "version": "6.1.6",
   "description": "Library for sharing components and modules between Procosys MC webapp, Comm webapp and Echo.",
   "main": "dist/index.js",
   "scripts": {
@@ -21,7 +21,8 @@
     "dist"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com"
+    "registry": "https://registry.npmjs.org",
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@equinor/procosys-webapp-components",
-  "version": "6.1.4",
+  "name": "@procosys/procosys-webapp-components",
+  "version": "1.0.0",
   "description": "Library for sharing components and modules between Procosys MC webapp, Comm webapp and Echo.",
   "main": "dist/index.js",
   "scripts": {
@@ -20,6 +20,9 @@
   "files": [
     "dist"
   ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/equinor/procosys-webapp-components.git"

--- a/package.json
+++ b/package.json
@@ -20,9 +20,6 @@
   "files": [
     "dist"
   ],
-  "publishConfig": {
-    "registry": "https://npm.pkg.github.com"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/equinor/procosys-webapp-components.git"


### PR DESCRIPTION
## Summary
Switches package publishing from GitHub Packages back to npmjs.com, using npm Trusted Publisher (OIDC) for tokenless authentication.

## Changes
- **package.json**: name -> @equinor/procosys-webapp-components, version -> 6.1.6, publishConfig registry -> npmjs.org with ccess: public`n- **.github/workflows/publish.yml**: id-token: write permission for OIDC, npmjs registry-url, @equinor scope, npm upgrade step for OIDC support, removed PROCOSYS_NPM_TOKEN env
- **README.md**: updated install/publish docs for npmjs @equinor scope and Trusted Publisher/OIDC

## Notes
The package on npmjs.com must have this repo + publish.yml configured as a Trusted Publisher. The old PROCOSYS_NPM_TOKEN secret can be removed.